### PR TITLE
Fix setup.py - use python3 compatible syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from distutils.core import setup
 
 #import __version__
-execfile('src/robots/__init__.py')
+exec(open('src/robots/__init__.py').read())
 
 
 setup(name='pyRobots',


### PR DESCRIPTION
Fix #7 by updating `exec` syntax

Per https://docs.python.org/3.3/whatsnew/3.0.html?highlight=execfile#builtins:

    Removed execfile(). Instead of execfile(fn) use exec(open(fn).read()).